### PR TITLE
Fix: Update DisplayName to 'Image Size Tools'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ Repository = "https://github.com/TheLustriVA/ComfyUI-Image-Size-Tools"
 
 [tool.comfy]
 PublisherId = "kgbicheno"
-DisplayName = "KGBicheno"
+DisplayName = "Image Size Tool"
 Icon = "https://raw.githubusercontent.com/TheLustriVA/ComfyUI-Image-Size-Tools/main/assets/icon.svg"
 Banner = "https://raw.githubusercontent.com/TheLustriVA/ComfyUI-Image-Size-Tools/main/assets/banner.svg"
 requires-comfyui = ">=0.1.0"


### PR DESCRIPTION
Fix: Update DisplayName to 'Image Size Tools' for proper ComfyUI Manager display

The node pack was coming up under my name instead of the actual pack in ComfyUI's node manager. This should fix that.

References #1